### PR TITLE
Implement/123 endpoints de back para maps

### DIFF
--- a/src/features/maps/components/MapView.tsx
+++ b/src/features/maps/components/MapView.tsx
@@ -1,8 +1,9 @@
 import { GoogleMap } from '@react-google-maps/api';
 import { useUserLocationStore } from '../store/userLocation.store';
 import { MarkerList } from './MarkerList';
-import { Parking } from '../../../store/parking.store';
+import { Parking, useParkingStore  } from '../../../store/parking.store';
 import Loader from '../../../shared/ui/components/Loader'; // Asegúrate que la ruta es correcta
+import { useEffect } from 'react';
 
 const containerStyle = { width: '100%', height: '100vh' };
 
@@ -12,8 +13,23 @@ type MapViewProps = {
 
 export const MapView = ({ onParkingSelect }: MapViewProps) => {
   const location = useUserLocationStore((s) => s.location);
+  const {
+    //nearbyParkings,
+    isLoadingNearby,
+    fetchNearbyParkings
+  } = useParkingStore();
 
-  if (!location) return <Loader fullScreen />;
+  useEffect(() => {
+    if (location) {
+      // sólo cuando location exista, pedimos al backend
+      fetchNearbyParkings(location.lat, location.lng, 5);
+    }
+  }, [location, fetchNearbyParkings]);
+
+  if (!location || isLoadingNearby) {
+    // mostramos loader mientras obtenemos la ubicación o los parkings
+    return <Loader fullScreen />;
+  }
 
   return (
     <GoogleMap

--- a/src/features/maps/components/MarkerList.tsx
+++ b/src/features/maps/components/MarkerList.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from "react";
-import useMapStore from "../store/useMap.store";
+// import { useEffect } from "react";
+// import useMapStore from "../store/useMap.store";
 import ParkingMarker from "./ParkingMarker";
-import { Parking } from "../../../store/parking.store";
+import { Parking, useParkingStore } from "../../../store/parking.store";
 import Loader from "../../../shared/ui/components/Loader"; 
 
 type MarkerListProps = {
@@ -9,20 +9,31 @@ type MarkerListProps = {
 };
 
 export const MarkerList = ({ onParkingSelect }: MarkerListProps) => {
-  const filteredParkings = useMapStore((state) => state.filteredParkings);
-  const initializeFilteredParkings = useMapStore((state) => state.initializeFilteredParkings);
-  const isLoading = useMapStore((state) => state.isLoading); 
-  useEffect(() => {
-    initializeFilteredParkings();
-  }, [initializeFilteredParkings]);
+  // const filteredParkings = useMapStore((state) => state.filteredParkings);
+  // const initializeFilteredParkings = useMapStore((state) => state.initializeFilteredParkings);
+  // const isLoading = useMapStore((state) => state.isLoading);
 
-  if (isLoading) return <Loader fullScreen />; 
+  // 1️⃣ Leemos del store el array de parkings cercanos
+  const nearbyParkings = useParkingStore((state) => state.nearbyParkings);
+
+  // 2️⃣ Flag de carga para parkings cercanos
+  const isLoadingNearby = useParkingStore((state) => state.isLoadingNearby);
+
+  // useEffect(() => {
+  //   initializeFilteredParkings();
+  // }, [initializeFilteredParkings]);
+
+  if (isLoadingNearby) return <Loader fullScreen />; 
 
   return (
     <>
-      {filteredParkings.length > 0 ? (
-        filteredParkings.map((p) => (
-          <ParkingMarker key={p.id} parking={p} onClick={() => onParkingSelect(p)} />
+      {nearbyParkings.length > 0 ? (
+        nearbyParkings.map((p) => (
+          <ParkingMarker
+            key={p.id}
+            parking={p}
+            onClick={() => onParkingSelect(p)}
+          />
         ))
       ) : (
         <p>No se encontraron estacionamientos con los filtros seleccionados.</p>

--- a/src/features/parkings/components/ParkingCard.tsx
+++ b/src/features/parkings/components/ParkingCard.tsx
@@ -80,7 +80,10 @@ export const ParkingCard = ({ parking }: ParkingProfileProps) => {
         <Box display="flex" justifyContent="space-between" alignItems="center" mt={0.5}>
           <Typography variant="body2" color="success.main" fontWeight={500}>
             {/* {parking.distance} km ({parking.estimatedTime}) */}
-            {parking.distance} km ("11 min")
+            {/* {parking.distance.toFixed()} km ("11 min") */}
+            {parking.distance != null
+            ? `${parking.distance.toFixed(0)} km`
+            : '—'}
           </Typography>
           <Box display="flex" alignItems="center" gap={0.5}>
             <Typography variant="body2" fontWeight={500}>

--- a/src/features/parkings/services/ParkingService.ts
+++ b/src/features/parkings/services/ParkingService.ts
@@ -1,4 +1,5 @@
 import { FormParkingValues } from "../../../shared/types";
+import { handleError } from "../../../shared/utils/handleError";
 import { Parking } from "../../../store/parking.store";
 
 import { ChangePasswordFormData } from "../types";
@@ -129,6 +130,31 @@ export async function deleteParking() {
   }
 }
 
+
+// 📌 Define el tipo que devuelve tu back para cada parking cercano
+interface ApiNearbyParking {
+  id: string;
+  name: string;
+  address: string;
+  location: { latitude: number; longitude: number };
+  distance: number;
+  currentAvailability: number;
+  hourlyRate: number;
+  parkingPhone: string;
+  parkingImageUrl: string;
+}
+
+export async function getNearbyParkings(lat: number, lon: number, radius: number): Promise<ApiNearbyParking[]> {
+  try {
+    const { data } = await api.get<{ data: ApiNearbyParking[] }>('/parkings/nearby', {
+      params: { lat, lon, radius },
+    });
+    return data.data;
+  } catch (err) {
+    handleError(err);
+    throw err;
+  }
+}
 const parkingService = {
  
     async updateParkingProfile(data: Omit<FormParkingValues, 'imageParking'> & { imageParking: File | null }) {

--- a/src/features/parkings/store/parkingEditor.store.ts
+++ b/src/features/parkings/store/parkingEditor.store.ts
@@ -1,34 +1,34 @@
-import { create } from 'zustand';
-import { Parking } from '../../../shared/types/parking';
+// import { create } from 'zustand';
+// import { Parking } from '../../../shared/types/parking';
 
-interface ParkingEditorStore extends Parking {
-  setParkingData: (data: Partial<Parking>) => void;
-  reset: () => void;
-}
+// interface ParkingEditorStore extends Parking {
+//   setParkingData: (data: Partial<Parking>) => void;
+//   reset: () => void;
+// }
 
-export const useParkingEditorStore = create<ParkingEditorStore>((set) => ({
-  id: '',
-  name: '',
-  address: '',
-  contactNumber: '',
-  hourlyRate: 0,
-  totalCapacity: 0,
-  availableSpots: 0,
-  lat: 0,
-  lng: 0,
-  distance: 0,
+// export const useParkingEditorStore = create<ParkingEditorStore>((set) => ({
+//   id: '',
+//   name: '',
+//   address: '',
+//   contactNumber: '',
+//   hourlyRate: 0,
+//   totalCapacity: 0,
+//   availableSpots: 0,
+//   lat: 0,
+//   lng: 0,
+//   distance: 0,
 
-  setParkingData: (data) => set((state) => ({ ...state, ...data })),
-  reset: () =>
-    set({
-      id: '',
-      name: '',
-      address: '',
-      contactNumber: '',
-      hourlyRate: 0,
-      totalCapacity: 0,
-      availableSpots: 0,
-      lat: 0,
-      lng: 0,
-    }),
-}));
+//   setParkingData: (data) => set((state) => ({ ...state, ...data })),
+//   reset: () =>
+//     set({
+//       id: '',
+//       name: '',
+//       address: '',
+//       contactNumber: '',
+//       hourlyRate: 0,
+//       totalCapacity: 0,
+//       availableSpots: 0,
+//       lat: 0,
+//       lng: 0,
+//     }),
+// }));

--- a/src/shared/types/parking.ts
+++ b/src/shared/types/parking.ts
@@ -1,18 +1,18 @@
-export interface Parking {
-  id: string;
-  name: string;
-  address: string;
-  contactNumber: string;
-  hourlyRate: number;
-  totalCapacity: number;
-  availableSpots: number;
-  lat: number;
-  lng: number;
-  imageParking?: string;
-  openTime?: string;
-  closeTime?: string;
-  rating?: number;
-  estimatedTime?: string;
-  distance: number; 
-  isOpen?: boolean;
-}
+// export interface Parking {
+//   id: string;
+//   name: string;
+//   address: string;
+//   contactNumber: string;
+//   hourlyRate: number;
+//   totalCapacity: number;
+//   availableSpots: number;
+//   lat: number;
+//   lng: number;
+//   imageParking?: string;
+//   openTime?: string;
+//   closeTime?: string;
+//   rating?: number;
+//   estimatedTime?: string;
+//   distance: number; 
+//   isOpen?: boolean;
+// }

--- a/src/store/parking.store.ts
+++ b/src/store/parking.store.ts
@@ -1,5 +1,6 @@
 import {create} from 'zustand';
 import { persist } from "zustand/middleware";
+import { getNearbyParkings } from "../features/parkings/services/ParkingService";
 
 export interface Parking {
   id: string;
@@ -38,6 +39,11 @@ interface ParkingState {
     // Disponibilidad por ID de parking
     availability: ParkingAvailability;
     setAvailability: (parkingId: string, slots: number) => void;
+
+    nearbyParkings: Parking[];
+    isLoadingNearby: boolean;
+    fetchNearbyParkings: (lat: number, lon: number, radius: number) => Promise<void>;
+
   }
 
   const initialState : Parking = {
@@ -85,12 +91,52 @@ interface ParkingState {
               [parkingId]: slots,
             },
           })),
-      }),{
+        
+        nearbyParkings: [],
+        isLoadingNearby: false,
+
+        fetchNearbyParkings: async (lat, lon, radius) => {
+          set({ isLoadingNearby: true });
+          try {
+            // 1️⃣ llama al método de tu servicio
+            const apiItems = await getNearbyParkings(lat, lon, radius);
+
+            // 2️⃣ mapea ApiNearbyParking → Parking de tu store
+            const mapped = apiItems.map(item => ({
+              id: item.id,
+              imageParking: item.parkingImageUrl,
+              email: '',
+              totalSpots: 0,
+              hourlyRate: item.hourlyRate,
+              openTime: '',
+              closeTime: '',
+              parkingName: item.name,
+              parkingAddress: item.address,
+              parkingPhone: item.parkingPhone,
+              isParkingLoaded: true,
+              lat: item.location.latitude,
+              lng: item.location.longitude,
+              availableSpots: item.currentAvailability,
+              rating: 0,
+              distance: item.distance,
+              isOpen: true,
+              ownerId: '',
+            }));
+
+            // 3️⃣ guarda en el store
+            set({ nearbyParkings: mapped });
+          } finally {
+            set({ isLoadingNearby: false });
+          }
+        },
+      }),
+      {
         name: "parking-storage",
         partialize: (state) => ({ 
           parking: state.parking,
           selected: state.selected,
           availability: state.availability,
+          nearbyParkings: state.nearbyParkings,
         }), 
       }
     )


### PR DESCRIPTION
**src/services/parking.service.ts**

- Añadido getNearbyParkings(lat, lon, radius) que llama a /parkings/nearby y devuelve el array tipado.

**src/store/parking.store.ts**

- Introducidos en el store los campos nearbyParkings, isLoadingNearby y la acción fetchNearbyParkings.

- fetchNearbyParkings invoca el servicio, mapea la respuesta a nuestro tipo Parking y actualiza el estado.

**src/components/MapView.tsx**

- Disparo de fetchNearbyParkings en un useEffect tras obtener la ubicación.

- Mantenimiento del loader full-screen mientras isLoadingNearby o location son falsy.

**src/components/MarkerList.tsx**

- Sustituido el mock de filteredParkings por nearbyParkings del store.

- Renderizado de cada parking mediante <ParkingMarker> y mensaje de “no se encontraron” si el array viene vacío.

**src/components/ParkingCard.tsx**

- Formateo de parking.distance con toFixed(1) y comprobación de undefined para evitar decimales infinitos y errores de tipo.

Comentar código que no se usa.